### PR TITLE
Update Dockerfile to track phylodb version

### DIFF
--- a/phylodb/Dockerfile
+++ b/phylodb/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11
 
-COPY build/libs/phylodb-1.0.0.jar app.jar
+COPY build/libs/phylodb-1.2.0.jar app.jar
 
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
Phylodb version is out of date in the Dockerfile, which cause the docker build to fail.